### PR TITLE
Fix release: ensure publish runs before jreleaserDeploy

### DIFF
--- a/sdk-coroutines/build.gradle.kts
+++ b/sdk-coroutines/build.gradle.kts
@@ -147,3 +147,7 @@ jreleaser {
         }
     }
 }
+
+tasks.named("jreleaserDeploy") {
+    dependsOn(tasks.named("publish"))
+}

--- a/sdk-shared/build.gradle.kts
+++ b/sdk-shared/build.gradle.kts
@@ -126,3 +126,7 @@ jreleaser {
         }
     }
 }
+
+tasks.named("jreleaserDeploy") {
+    dependsOn(tasks.named("publish"))
+}

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -143,3 +143,7 @@ jreleaser {
         }
     }
 }
+
+tasks.named("jreleaserDeploy") {
+    dependsOn(tasks.named("publish"))
+}


### PR DESCRIPTION
## Summary
- The RC5 release job failed because `:sdk-shared:jreleaserDeploy` executed before `:sdk-shared:publish`, leaving `build/staging-deploy` empty.
- With a single module, Gradle honored CLI task order; with three modules the scheduler interleaved tasks and broke the implicit ordering.
- Fix: each module now declares `jreleaserDeploy.dependsOn(publish)` so the task graph expresses the real constraint.

See failing run: https://github.com/starfederation/datastar-kotlin/actions/runs/24643903028/job/72052911633
